### PR TITLE
Add instructions for macOS compilation (Intel and Apple Silicon)

### DIFF
--- a/doc/INSTALL
+++ b/doc/INSTALL
@@ -8,6 +8,12 @@ The following packages are required to build and run neo:
 - build-essential: make and g++ are used for compilation
 - libncurses-dev: neo uses ncursesw to control the terminal
 
+For macOS, make sure to include your ncurses include and library directories 
+before configuring the Makefile, for example (brew):
+
+export LDFLAGS="-L/opt/homebrew/opt/ncurses/lib"
+export CPPFLAGS="-I/opt/homebrew/opt/ncurses/include"
+
 You will need to ensure that your C++ compiler supports C++11 and that
 your autoconf version is at least 2.61. g++ and clang++ should both work
 for compilation.


### PR DESCRIPTION
Confirmed this compiles on Apple Silicon with brew ncurses
```
% uname -a
21.2.0 Darwin Kernel Version 21.2.0: Sun Nov 28 20:29:10 PST 2021; root:xnu-8019.61.5~1/RELEASE_ARM64_T8101 arm64
% brew info ncurses
ncurses: stable 6.3 (bottled) [keg-only]
```