### PR TITLE
Use current time instead of hardcoded value as random seed

### DIFF
--- a/src/cloud.cpp
+++ b/src/cloud.cpp
@@ -95,7 +95,7 @@ void Cloud::Reset() {
         droplet.Reset();
 
     // Reset all the RNG stuff
-    mt.seed(0x1234567);
+    mt.seed(high_resolution_clock::now().time_since_epoch().count());
 
     int8_t lowPair, highPair;
     if (_numColorPairs < 3) {


### PR DESCRIPTION
Currently, the random seed is hard coded to be 0x1234567, which leads to the output being exactly the same every time you reset it by pressing the space bar.