### PR TITLE
remove pseudorunes from Runic

### DIFF
--- a/src/cloud.cpp
+++ b/src/cloud.cpp
@@ -170,7 +170,7 @@ void Cloud::InitChars() {
         { Charset::HEBREW, {{L'\u0590', L'\u05FF'}, {L'\uFB1D', L'\uFB4F'}} },
         { Charset::DEVANAGARI, {{L'\u0900', L'\u097F'}} },
         { Charset::BRAILLE, {{L'\u2800', L'\u28FF'}} },
-        { Charset::RUNIC, {{L'\u16A0', L'\u16FF'}} },
+        { Charset::RUNIC, {{L'\u16A0', L'\u16F0'}} },
     };
     size_t numRanges = unicodeRanges.size();
     for (size_t range = 0; range < numRanges; range++) {


### PR DESCRIPTION
Most fonts don't carry them, resulting in garbage.

You might also consider eliminating characters after U+16EA:
 * punctuation: `᛫᛬᛭`
 * calendar symbols: `ᛮᛯᛰ`

Fixes #30